### PR TITLE
Add MinRelevance property and UI slider for memory control

### DIFF
--- a/ChatConversationControl/Controls/MemoryConversationControl.cs
+++ b/ChatConversationControl/Controls/MemoryConversationControl.cs
@@ -44,4 +44,19 @@ public class MemoryConversationControl : ConversationControl
         get => (string)GetValue(SelectedStorageIndexProperty);
         set => SetValue(SelectedStorageIndexProperty, value);
     }
+
+    /// <summary>
+    /// Identifies the MinRelevance dependency property.
+    /// </summary>
+    public static readonly DependencyProperty MinRelevanceProperty =
+        DependencyProperty.Register(nameof(MinRelevance), typeof(double), typeof(ConversationControl), new PropertyMetadata(0.0));
+
+    /// <summary>
+    /// Gets or sets the minimum relevance value.
+    /// </summary>
+    public double MinRelevance
+    {
+        get => (double)GetValue(MinRelevanceProperty);
+        set => SetValue(MinRelevanceProperty, value);
+    }
 }

--- a/ChatConversationControl/Themes/ConversationControlStyle.xaml
+++ b/ChatConversationControl/Themes/ConversationControlStyle.xaml
@@ -25,12 +25,18 @@
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <!-- ToggleButton for UseHistory and Slider for MinRelevance -->
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Grid.Row="0" Grid.Column="0" Margin="5">
+                            <ToggleButton Content="Use History" IsChecked="{Binding UseHistory, RelativeSource={RelativeSource TemplatedParent}}" Margin="5" HorizontalAlignment="Left"/>
+                        </StackPanel>
 
                         <!-- Buttons for clearing, saving, and loading conversation -->
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="0" Margin="5">
-                            <!-- ToggleButton for UseHistory -->
-                            <ToggleButton Content="Use History" IsChecked="{Binding UseHistory, RelativeSource={RelativeSource TemplatedParent}}" Margin="5" HorizontalAlignment="Left"/>
-
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="0" Grid.Column="1" Margin="5">
                             <Button Command="{Binding ClearConversationCommand, RelativeSource={RelativeSource TemplatedParent}}" ToolTip="Clear conversation">
                                 <StackPanel Orientation="Horizontal">
                                     <ui:SymbolIcon Symbol="Delete24" Margin="0,0,5,0"/>
@@ -49,7 +55,7 @@
                         </StackPanel>
 
                         <!-- ScrollViewer for displaying conversation messages -->
-                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Grid.Row="1">
+                        <ScrollViewer Grid.Column="0" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Grid.Row="1" Grid.ColumnSpan="2">
                             <ItemsControl x:Name="ConversationItemsControl" Margin="5" ItemsSource="{Binding ConversationList, RelativeSource={RelativeSource TemplatedParent}}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate DataType="{x:Type messages:MessageItem}">
@@ -65,7 +71,7 @@
                         </ScrollViewer>
 
                         <!-- TextBox for entering prompt -->
-                        <Grid Grid.Row="2" Margin="5">
+                        <Grid Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2" Margin="5">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
@@ -107,7 +113,7 @@
                         </Grid>
 
                         <!-- Loading Spinner -->
-                        <ui:ProgressRing Grid.Row="1" IsIndeterminate="True" Visibility="{TemplateBinding IsLoading, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        <ui:ProgressRing Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" IsIndeterminate="True" Visibility="{Binding IsLoading, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                     </Grid>
                 </ControlTemplate>

--- a/ChatConversationControl/Themes/MemoryConversationControlStyle.xaml
+++ b/ChatConversationControl/Themes/MemoryConversationControlStyle.xaml
@@ -21,33 +21,51 @@
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="0" Margin="5">
-                            <!-- ToggleButton for UseHistory -->
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <!-- ToggleButton for UseHistory and Slider for MinRelevance -->
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Grid.Row="0" Grid.Column="0" Margin="5">
                             <ToggleButton Content="Use History" IsChecked="{Binding UseHistory, RelativeSource={RelativeSource TemplatedParent}}" Margin="5" HorizontalAlignment="Left"/>
-                            <Button Command="{Binding ClearConversationCommand, RelativeSource={RelativeSource TemplatedParent}}" 
-                                    ToolTip="Clear conversation">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="5,0,0,0">
+                                <Label Content="Min Relevance:" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <Slider Minimum="0" Maximum="1" Value="{Binding MinRelevance, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+                                        HorizontalAlignment="Center" HorizontalContentAlignment="Center" 
+                                        TickFrequency="0.1"
+                                        IsSnapToTickEnabled="True"
+                                        VerticalAlignment="Top"
+                                        Width="100"
+                                        Margin="0,0,5,0"/>
+                                <TextBlock Text="{Binding MinRelevance, RelativeSource={RelativeSource TemplatedParent}, StringFormat=F2}" 
+                                           VerticalAlignment="Center" 
+                                           Margin="5,0,0,0"/>
+                            </StackPanel>
+                        </StackPanel>
+
+                        <!-- Buttons for clearing, saving, and loading conversation -->
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="0" Grid.Column="1" Margin="5">
+                            <Button Command="{Binding ClearConversationCommand, RelativeSource={RelativeSource TemplatedParent}}" ToolTip="Clear conversation">
                                 <StackPanel Orientation="Horizontal">
                                     <ui:SymbolIcon Symbol="Delete24" Margin="0,0,5,0"/>
                                 </StackPanel>
                             </Button>
-                            <Button Command="{Binding SaveConversationCommand, RelativeSource={RelativeSource TemplatedParent}}" 
-                                    ToolTip="Save conversation" Margin="5,0,0,0">
+                            <Button Command="{Binding SaveConversationCommand, RelativeSource={RelativeSource TemplatedParent}}" ToolTip="Save conversation" Margin="5,0,0,0">
                                 <StackPanel Orientation="Horizontal">
                                     <ui:SymbolIcon Symbol="SaveEdit24" Margin="0,0,5,0"/>
                                 </StackPanel>
                             </Button>
-                            <Button Command="{Binding LoadConversationCommand, RelativeSource={RelativeSource TemplatedParent}}" 
-                                    ToolTip="Load conversation" Margin="5,0,0,0">
+                            <Button Command="{Binding LoadConversationCommand, RelativeSource={RelativeSource TemplatedParent}}" ToolTip="Load conversation" Margin="5,0,0,0">
                                 <StackPanel Orientation="Horizontal">
                                     <ui:SymbolIcon Symbol="SelectObject24"  Margin="0,0,5,0"/>
                                 </StackPanel>
                             </Button>
-                            <ComboBox ItemsSource="{TemplateBinding StorageIndexes}" 
-                                  SelectedItem="{Binding SelectedStorageIndex, RelativeSource={RelativeSource TemplatedParent}}" 
-                                  Margin="5,0,0,0"/>
                         </StackPanel>
+
                         <!-- ScrollViewer for displaying conversation messages -->
-                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Grid.Row="1">
+                        <ScrollViewer Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                             <ItemsControl x:Name="ConversationItemsControl" Margin="5" ItemsSource="{Binding ConversationList, RelativeSource={RelativeSource TemplatedParent}}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate DataType="{x:Type messages:MessageItem}">
@@ -61,7 +79,7 @@
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
                         </ScrollViewer>
-                        <Grid Grid.Row="2" Margin="5">
+                        <Grid Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2" Margin="5">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>

--- a/ChatConversationControl/ViewModels/BaseConversationControlViewModel.cs
+++ b/ChatConversationControl/ViewModels/BaseConversationControlViewModel.cs
@@ -172,6 +172,7 @@ public abstract partial class BaseConversationControlViewModel : ObservableObjec
                     {
                         ColorString = "Green"
                     };
+
                     ConversationList.Add(assistantMessageItem);
                     ConversationChatHistory.Add(assistantChatMessageContent);
 

--- a/WPFUiDesktopApp/ViewModels/UserControls/MemoryConversationControlViewModel.cs
+++ b/WPFUiDesktopApp/ViewModels/UserControls/MemoryConversationControlViewModel.cs
@@ -19,6 +19,11 @@ public partial class MemoryConversationControlViewModel : BaseConversationContro
     private Task? _loadIndexesTask;
 
     /// <summary>
+    /// Gets or sets the minimum relevance.
+    /// </summary>
+    [ObservableProperty] private double _minRelevance = .6;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="MemoryConversationControlViewModel"/> class.
     /// </summary>
     /// <param name="memoryOperationExecutor">The executor for memory operations.</param>
@@ -113,10 +118,20 @@ public partial class MemoryConversationControlViewModel : BaseConversationContro
                     await memoryServiceDecorator.AskAsync(
                         promptText,
                         StorageManagementViewModel.SelectedItem,
+                        minRelevance: MinRelevance,
                         cancellationToken: cancellationToken), cancellationToken);
 
             if (memoryAnswer.NoResult || string.IsNullOrEmpty(memoryAnswer.Result))
             {
+                // display a message to the user
+                var uiMessageBox = new Wpf.Ui.Controls.MessageBox
+                {
+                    Title = "Memory Search - No result",
+                    Content =
+                        $"No result could be found for {MinRelevance}.",
+                };
+
+                _ = await uiMessageBox.ShowDialogAsync(cancellationToken: cancellationToken);
                 return;
             }
 
@@ -125,6 +140,10 @@ public partial class MemoryConversationControlViewModel : BaseConversationContro
         catch (ArgumentOutOfRangeException ex)
         {
             // TODO: Handle the System.ArgumentOutOfRangeException
+        }
+        catch (TaskCanceledException ex)
+        {
+            // TODO: Handle the System.Threading.Tasks.TaskCanceledException
         }
         finally
         {

--- a/WPFUiDesktopApp/Views/Pages/OllamaPage.xaml
+++ b/WPFUiDesktopApp/Views/Pages/OllamaPage.xaml
@@ -79,7 +79,8 @@
                                                          IsLoading="{Binding IsLoading}"
                                                          SelectedStorageIndex="{Binding StorageManagementViewModel.SelectedItem, Mode=TwoWay}"
                                                          StorageIndexes="{Binding StorageManagementViewModel.StorageIndexes, Mode=TwoWay}"
-                                                         UseHistory="{Binding Path=UseHistory}"/>
+                                                         UseHistory="{Binding Path=UseHistory}"
+                                                         MinRelevance="{Binding MinRelevance, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"/>
                 </Grid>
             </ui:TabViewItem>
 


### PR DESCRIPTION
Introduce MinRelevance property to MemoryConversationControl and bind it to the view model. Update UI to include a slider for adjusting MinRelevance, along with a label and text block. Modify layout in ConversationControlStyle.xaml and MemoryConversationControlStyle.xaml to accommodate the new slider. Update ExecuteMemoryOperationAsync method to use MinRelevance and add error handling for TaskCanceledException. Notify users when no results are found for the given MinRelevance value.